### PR TITLE
Add support for parsing and injecting OTLP headers from environment/config

### DIFF
--- a/pkg/base/monitoring/colibri-monitoring-base/monitoring.go
+++ b/pkg/base/monitoring/colibri-monitoring-base/monitoring.go
@@ -4,9 +4,19 @@ import (
 	"context"
 )
 
+type SpanKind string
+
+const (
+	SpanKindInternal SpanKind = "internal"
+	SpanKindClient   SpanKind = "client"
+	SpanKindServer   SpanKind = "server"
+	SpanKindProducer SpanKind = "producer"
+	SpanKindConsumer SpanKind = "consumer"
+)
+
 // Monitoring is a contract to implement all necessary functions
 type Monitoring interface {
-	StartTransaction(ctx context.Context, name string) (any, context.Context)
+	StartTransaction(ctx context.Context, name string, kind SpanKind) (any, context.Context)
 	EndTransaction(transaction any)
 	StartTransactionSegment(ctx context.Context, name string, attributes map[string]string) any
 	AddTransactionAttribute(transaction any, key string, value string)

--- a/pkg/base/monitoring/colibri-monitoring-base/others.go
+++ b/pkg/base/monitoring/colibri-monitoring-base/others.go
@@ -13,8 +13,8 @@ func NewOthers() Monitoring {
 	return &others{}
 }
 
-func (m *others) StartTransaction(ctx context.Context, name string) (any, context.Context) {
-	logging.Debug(ctx).Msgf("Starting transaction Monitoring with name %s", name)
+func (m *others) StartTransaction(ctx context.Context, name string, kind SpanKind) (any, context.Context) {
+	logging.Debug(ctx).Msgf("Starting transaction %s Monitoring with name %s", kind, name)
 	return nil, ctx
 }
 

--- a/pkg/base/monitoring/colibri-otel/open_telemetry.go
+++ b/pkg/base/monitoring/colibri-otel/open_telemetry.go
@@ -99,7 +99,7 @@ func StartOpenTelemetryMonitoring() colibrimonitoringbase.Monitoring {
 }
 
 func (m *MonitoringOpenTelemetry) StartTransaction(ctx context.Context, name string, kind colibrimonitoringbase.SpanKind) (any, context.Context) {
-	ctx, span := m.tracer.Start(ctx, name, trace.WithSpanKind(m.kindToOpenTelemetry(kind)))
+	ctx, span := m.tracer.Start(ctx, name, trace.WithSpanKind(kindToOpenTelemetry(kind)))
 	return span, ctx
 }
 
@@ -151,7 +151,7 @@ func (m *MonitoringOpenTelemetry) GetSQLDBDriverName() string {
 	return driverName
 }
 
-func (m *MonitoringOpenTelemetry) kindToOpenTelemetry(kind colibrimonitoringbase.SpanKind) trace.SpanKind {
+func kindToOpenTelemetry(kind colibrimonitoringbase.SpanKind) trace.SpanKind {
 	switch kind {
 	case colibrimonitoringbase.SpanKindClient:
 		return trace.SpanKindClient

--- a/pkg/base/monitoring/colibri-otel/open_telemetry.go
+++ b/pkg/base/monitoring/colibri-otel/open_telemetry.go
@@ -98,8 +98,8 @@ func StartOpenTelemetryMonitoring() colibrimonitoringbase.Monitoring {
 	return &MonitoringOpenTelemetry{tracer: tracer}
 }
 
-func (m *MonitoringOpenTelemetry) StartTransaction(ctx context.Context, name string) (any, context.Context) {
-	ctx, span := m.tracer.Start(ctx, name)
+func (m *MonitoringOpenTelemetry) StartTransaction(ctx context.Context, name string, kind colibrimonitoringbase.SpanKind) (any, context.Context) {
+	ctx, span := m.tracer.Start(ctx, name, trace.WithSpanKind(m.kindToOpenTelemetry(kind)))
 	return span, ctx
 }
 
@@ -149,4 +149,21 @@ func (m *MonitoringOpenTelemetry) GetSQLDBDriverName() string {
 		logging.Fatal(context.Background()).Msgf("could not get sql db driver name: %v", err)
 	}
 	return driverName
+}
+
+func (m *MonitoringOpenTelemetry) kindToOpenTelemetry(kind colibrimonitoringbase.SpanKind) trace.SpanKind {
+	switch kind {
+	case colibrimonitoringbase.SpanKindClient:
+		return trace.SpanKindClient
+	case colibrimonitoringbase.SpanKindServer:
+		return trace.SpanKindServer
+	case colibrimonitoringbase.SpanKindProducer:
+		return trace.SpanKindProducer
+	case colibrimonitoringbase.SpanKindConsumer:
+		return trace.SpanKindConsumer
+	case colibrimonitoringbase.SpanKindInternal:
+		return trace.SpanKindInternal
+	default:
+		return trace.SpanKindUnspecified
+	}
 }

--- a/pkg/base/monitoring/colibri-otel/open_telemetry.go
+++ b/pkg/base/monitoring/colibri-otel/open_telemetry.go
@@ -53,21 +53,18 @@ func StartOpenTelemetryMonitoring() colibrimonitoringbase.Monitoring {
 		otlptracehttp.WithEndpoint(config.OTEL_EXPORTER_OTLP_ENDPOINT),
 		otlptracehttp.WithInsecure(),
 	}
+
 	if config.OTEL_EXPORTER_OTLP_HEADERS != "" {
-		// The OTEL spec uses OTEL_EXPORTER_OTLP_HEADERS as a comma-separated list of key=value pairs
-		// otlptracehttp supports passing headers via WithHeaders(map[string]string)
 		headers := map[string]string{}
-		pairs := os.Getenv(config.ENV_OTEL_EXPORTER_OTLP_HEADERS)
-		// Fallback to config value if needed
-		if pairs == "" {
-			pairs = config.OTEL_EXPORTER_OTLP_HEADERS
-		}
+		pairs := config.OTEL_EXPORTER_OTLP_HEADERS
+
 		for _, part := range splitAndTrim(pairs, ",") {
 			kv := splitAndTrim(part, "=")
 			if len(kv) == 2 {
 				headers[kv[0]] = kv[1]
 			}
 		}
+
 		if len(headers) > 0 {
 			options = append(options, otlptracehttp.WithHeaders(headers))
 		}

--- a/pkg/base/monitoring/colibri-otel/open_telemetry_test.go
+++ b/pkg/base/monitoring/colibri-otel/open_telemetry_test.go
@@ -3,21 +3,40 @@ package colibri_otel
 import (
 	"testing"
 
+	colibrimonitoringbase "github.com/colibriproject-dev/colibri-sdk-go/pkg/base/monitoring/colibri-monitoring-base"
 	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/otel/trace"
 )
 
-func TestSplitHeadersConfig(t *testing.T) {
+func TestOpenTelemetry(t *testing.T) {
 
-	t.Run("Should return empty slice when headers is empty", func(t *testing.T) {
-		result := splitAndTrim("", ",")
+	t.Run("splitAndTrim", func(t *testing.T) {
+		t.Run("Should return empty slice when headers is empty", func(t *testing.T) {
+			result := splitAndTrim("", ",")
 
-		assert.Empty(t, result)
+			assert.Empty(t, result)
+		})
+
+		t.Run("Should return slice with trimmed values", func(t *testing.T) {
+			result := splitAndTrim("  a, b,  c  ", ",")
+
+			assert.Len(t, result, 3)
+			assert.Equal(t, []string{"a", "b", "c"}, result)
+		})
 	})
 
-	t.Run("Should return slice with trimmed values", func(t *testing.T) {
-		result := splitAndTrim("  a, b,  c  ", ",")
+	t.Run("KindToOpenTelemetry", func(t *testing.T) {
+		validations := map[colibrimonitoringbase.SpanKind]trace.SpanKind{
+			colibrimonitoringbase.SpanKindInternal: trace.SpanKindInternal,
+			colibrimonitoringbase.SpanKindClient:   trace.SpanKindClient,
+			colibrimonitoringbase.SpanKindServer:   trace.SpanKindServer,
+			colibrimonitoringbase.SpanKindProducer: trace.SpanKindProducer,
+			colibrimonitoringbase.SpanKindConsumer: trace.SpanKindConsumer,
+		}
 
-		assert.Len(t, result, 3)
-		assert.Equal(t, []string{"a", "b", "c"}, result)
+		for key, value := range validations {
+			result := kindToOpenTelemetry(key)
+			assert.Equal(t, value, result)
+		}
 	})
 }

--- a/pkg/base/monitoring/colibri-otel/open_telemetry_test.go
+++ b/pkg/base/monitoring/colibri-otel/open_telemetry_test.go
@@ -1,0 +1,23 @@
+package colibri_otel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSplitHeadersConfig(t *testing.T) {
+
+	t.Run("Should return empty slice when headers is empty", func(t *testing.T) {
+		result := splitAndTrim("", ",")
+
+		assert.Empty(t, result)
+	})
+
+	t.Run("Should return slice with trimmed values", func(t *testing.T) {
+		result := splitAndTrim("  a, b,  c  ", ",")
+
+		assert.Len(t, result, 3)
+		assert.Equal(t, []string{"a", "b", "c"}, result)
+	})
+}

--- a/pkg/base/monitoring/initialize.go
+++ b/pkg/base/monitoring/initialize.go
@@ -25,8 +25,8 @@ func UseOTELMonitoring() bool {
 }
 
 // StartTransaction start a transaction in context with name
-func StartTransaction(ctx context.Context, name string) (any, context.Context) {
-	return instance.StartTransaction(ctx, name)
+func StartTransaction(ctx context.Context, name string, kind colibrimonitoringbase.SpanKind) (any, context.Context) {
+	return instance.StartTransaction(ctx, name, kind)
 }
 
 func AddTransactionAttribute(transaction any, key string, value string) {

--- a/pkg/base/monitoring/monitoring_test.go
+++ b/pkg/base/monitoring/monitoring_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/config"
+	colibri_monitoring_base "github.com/colibriproject-dev/colibri-sdk-go/pkg/base/monitoring/colibri-monitoring-base"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,7 +25,7 @@ func monitoringTest(t *testing.T) {
 	t.Run("Should get transaction in context", func(t *testing.T) {
 		txnName := "txn-test"
 
-		_, ctx := StartTransaction(context.Background(), txnName)
+		_, ctx := StartTransaction(context.Background(), txnName, colibri_monitoring_base.SpanKindInternal)
 		transaction := GetTransactionInContext(ctx)
 		EndTransaction(transaction)
 

--- a/pkg/messaging/consumer.go
+++ b/pkg/messaging/consumer.go
@@ -6,6 +6,7 @@ import (
 	"sync"
 
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/monitoring"
+	colibrimonitoringbase "github.com/colibriproject-dev/colibri-sdk-go/pkg/base/monitoring/colibri-monitoring-base"
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/observer"
 
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/logging"
@@ -56,10 +57,11 @@ func startListener(c *consumer) {
 func processMessage(c *consumer, msg *ProviderMessage) {
 	ctxRoot := context.WithValue(context.Background(), logging.CorrelationIDParam, msg.CorrelationID)
 
-	txn, ctx := monitoring.StartTransaction(ctxRoot, fmt.Sprintf(messagingConsumerTransaction, c.queue))
+	txn, ctx := monitoring.StartTransaction(ctxRoot, fmt.Sprintf(messagingConsumerTransaction, c.queue), colibrimonitoringbase.SpanKindConsumer)
 	monitoring.AddTransactionAttribute(txn, logging.CorrelationIDParam, msg.CorrelationID)
 	monitoring.AddTransactionAttribute(txn, "action", msg.Action)
 	monitoring.AddTransactionAttribute(txn, "messageId", msg.ID.String())
+	monitoring.AddTransactionAttribute(txn, "span.kind", "CONSUMER")
 	defer monitoring.EndTransactionSegment(txn)
 
 	msg.AuthContext.SetInContext(ctx)

--- a/pkg/web/restserver/middlewares.go
+++ b/pkg/web/restserver/middlewares.go
@@ -78,7 +78,9 @@ func customAuthenticationContextFiberMiddleware() fiber.Handler {
 }
 
 func newOpenTelemetryFiberMiddleware() fiber.Handler {
-	return otelfiber.Middleware()
+	return otelfiber.Middleware(otelfiber.WithSpanNameFormatter(func(ctx *fiber.Ctx) string {
+		return fmt.Sprintf("%s - %s", ctx.Method(), ctx.Route().Path)
+	}))
 }
 
 func accessControlFiberMiddleware() fiber.Handler {


### PR DESCRIPTION
# Summary

This Pull Request enhances the OpenTelemetry monitoring implementation by introducing a utility function to process strings and updating the configuration for handling headers when setting up the OTLP exporter.

## Main Changes

 * Added a new utility function splitAndTrim to split strings by a delimiter, trim spaces, and ignore empty results.
 * Modified the setup for the OTLP exporter to support headers specified via OTEL_EXPORTER_OTLP_HEADERS (both environment variable and configuration fallback).
 * Refactored exporter initialization to append options dynamically based on header processing.