### PR TITLE
fix(messaging): unify providers to at-least-once delivery

### DIFF
--- a/.github/workflows/quality.yaml
+++ b/.github/workflows/quality.yaml
@@ -52,3 +52,4 @@ jobs:
             -Dsonar.tests=.
             -Dsonar.test.inclusions=**/*_test.go
             -Dsonar.go.coverage.reportPaths=coverage.txt
+            -Dsonar.coverage.exclusions=pkg/base/test/**

--- a/development-environment/gcp-emulator/init_pubsub.sh
+++ b/development-environment/gcp-emulator/init_pubsub.sh
@@ -4,8 +4,10 @@ export PUBSUB_EMULATOR_HOST=localhost:8686
 
 gcloud pubsub topics create COLIBRI_PROJECT_USER_CREATE
 gcloud pubsub topics create COLIBRI_PROJECT_FAIL_USER_CREATE
+gcloud pubsub topics create COLIBRI_PROJECT_FAIL_USER_CREATE_DLT
 
 gcloud pubsub subscriptions create COLIBRI_PROJECT_USER_CREATE_APP_CONSUMER --topic=COLIBRI_PROJECT_USER_CREATE
-gcloud pubsub subscriptions create COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER --topic=COLIBRI_PROJECT_FAIL_USER_CREATE
+gcloud pubsub subscriptions create COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER --topic=COLIBRI_PROJECT_FAIL_USER_CREATE \
+       --dead-letter-topic=projects/test-project/topics/COLIBRI_PROJECT_FAIL_USER_CREATE_DLT --max-delivery-attempts=5
 
-gcloud pubsub subscriptions create COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER_DLQ --topic=COLIBRI_PROJECT_FAIL_USER_CREATE --dead-letter-topic=projects/test-project/topics/COLIBRI_PROJECT_FAIL_USER_CREATE --max-delivery-attempts=5
+gcloud pubsub subscriptions create COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER_DLQ --topic=COLIBRI_PROJECT_FAIL_USER_CREATE_DLT

--- a/development-environment/localstack/start-localstack.sh
+++ b/development-environment/localstack/start-localstack.sh
@@ -7,8 +7,9 @@ awslocal sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:COLIBRI_PR
          --notification-endpoint arn:aws:sqs:us-east-1:000000000000:COLIBRI_PROJECT_USER_CREATE_APP_CONSUMER
 
 awslocal sns create-topic --name COLIBRI_PROJECT_FAIL_USER_CREATE
-awslocal sqs create-queue --queue-name COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER
 awslocal sqs create-queue --queue-name COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER_DLQ
+awslocal sqs create-queue --queue-name COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER \
+         --attributes '{"VisibilityTimeout":"1","RedrivePolicy":"{\"deadLetterTargetArn\":\"arn:aws:sqs:us-east-1:000000000000:COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER_DLQ\",\"maxReceiveCount\":\"2\"}"}'
 awslocal sns subscribe --topic-arn arn:aws:sns:us-east-1:000000000000:COLIBRI_PROJECT_FAIL_USER_CREATE \
          --protocol sqs \
          --notification-endpoint arn:aws:sqs:us-east-1:000000000000:COLIBRI_PROJECT_FAIL_USER_CREATE_APP_CONSUMER

--- a/pkg/base/test/wiremock_container.go
+++ b/pkg/base/test/wiremock_container.go
@@ -48,8 +48,11 @@ func newWiremockContainer(configPath string) *WiremockContainer {
 				Target: "/home/wiremock",
 			})
 		},
-		Cmd:        []string{"--local-response-templating"},
-		WaitingFor: wait.ForListeningPort(wiremockSvcPort),
+		Cmd: []string{"--local-response-templating"},
+		WaitingFor: wait.ForAll(
+			wait.ForListeningPort(wiremockSvcPort),
+			wait.ForHTTP("/__admin/mappings").WithPort(wiremockSvcPort),
+		),
 	}
 
 	return &WiremockContainer{wContainerRequest: &req, configPath: configPath}
@@ -62,10 +65,13 @@ func (c *WiremockContainer) start(ctx context.Context) {
 		Started:          true,
 	})
 	if err != nil {
-		logging.Fatal(ctx).Err(err)
+		logging.Fatal(ctx).Err(err).Msg("could not start wiremock container")
 	}
 
-	runningPort, _ := c.wContainer.MappedPort(ctx, wiremockSvcPort)
+	runningPort, err := c.wContainer.MappedPort(ctx, wiremockSvcPort)
+	if err != nil {
+		logging.Fatal(ctx).Err(err).Msg("could not get wiremock container mapped port")
+	}
 	c.instancePort = runningPort.Int()
 
 	logging.Info(ctx).Msgf("Test wiremock started at port: %s", runningPort.Port())

--- a/pkg/messaging/aws.go
+++ b/pkg/messaging/aws.go
@@ -29,14 +29,38 @@ type awsMessaging struct {
 	sqsService *sqs.SQS
 }
 
-type awsOriginalMessage struct{}
-
-func (a awsOriginalMessage) Ack() error {
-	return nil
+type awsOriginalMessage struct {
+	ctx           context.Context
+	sqsService    *sqs.SQS
+	queueUrl      *string
+	receiptHandle *string
 }
 
-func (a awsOriginalMessage) Nack(_ bool, _ error) error {
-	return nil
+// Ack deletes the message from the queue after successful processing.
+func (a awsOriginalMessage) Ack() error {
+	_, err := a.sqsService.DeleteMessageWithContext(a.ctx, &sqs.DeleteMessageInput{
+		QueueUrl:      a.queueUrl,
+		ReceiptHandle: a.receiptHandle,
+	})
+
+	return err
+}
+
+// Nack leaves the message in the queue. With requeue it becomes visible again
+// immediately; otherwise it reappears after the visibility timeout and the
+// queue's redrive policy routes it to the DLQ once maxReceiveCount is exceeded.
+func (a awsOriginalMessage) Nack(requeue bool, _ error) error {
+	if !requeue {
+		return nil
+	}
+
+	_, err := a.sqsService.ChangeMessageVisibilityWithContext(a.ctx, &sqs.ChangeMessageVisibilityInput{
+		QueueUrl:          a.queueUrl,
+		ReceiptHandle:     a.receiptHandle,
+		VisibilityTimeout: aws.Int64(0),
+	})
+
+	return err
 }
 
 func newAwsMessaging() *awsMessaging {
@@ -79,30 +103,42 @@ func (m *awsMessaging) consumer(ctx context.Context, c *consumer) (chan *Provide
 			msgs, err := m.readMessages(ctx, queueUrl)
 			if err != nil {
 				logging.Error(ctx).Err(err).Msgf(couldNotReceiveMsg, c.queue)
+				continue
 			}
 
 			if len(msgs.Messages) > 0 {
-				msg := msgs.Messages[0]
-
-				var n sqsNotification
-				if err = json.Unmarshal([]byte(*msg.Body), &n); err != nil {
-					logging.Error(ctx).Err(err).Msgf(couldNotReadMsgBody, *msg.MessageId, c.queue)
-				}
-
-				var pm ProviderMessage
-				if err = json.Unmarshal([]byte(n.Message), &pm); err != nil {
-					logging.Error(ctx).Err(err).Msgf(couldNotReadMsgBody, *msg.MessageId, c.queue)
-					return
-				}
-
-				pm.addOriginBrokerNotification(awsOriginalMessage{})
-				ch <- &pm
-				m.removeMessageFromQueue(ctx, queueUrl, msg)
+				m.handleMessage(ctx, c, queueUrl, msgs.Messages[0], ch)
 			}
 		}
 	}()
 
 	return ch, nil
+}
+
+// handleMessage unwraps the SNS notification and delivers the message to the consumer
+// channel with a real ack/nack bound to the SQS receipt handle. Malformed messages are
+// skipped without deletion so they redeliver after the visibility timeout and the
+// queue's redrive policy can route them to the DLQ.
+func (m *awsMessaging) handleMessage(ctx context.Context, c *consumer, queueUrl *sqs.GetQueueUrlOutput, msg *sqs.Message, ch chan *ProviderMessage) {
+	var n sqsNotification
+	if err := json.Unmarshal([]byte(*msg.Body), &n); err != nil {
+		logging.Error(ctx).Err(err).Msgf(couldNotReadMsgBody, *msg.MessageId, c.queue)
+		return
+	}
+
+	var pm ProviderMessage
+	if err := json.Unmarshal([]byte(n.Message), &pm); err != nil {
+		logging.Error(ctx).Err(err).Msgf(couldNotReadMsgBody, *msg.MessageId, c.queue)
+		return
+	}
+
+	pm.addOriginBrokerNotification(awsOriginalMessage{
+		ctx:           ctx,
+		sqsService:    m.sqsService,
+		queueUrl:      queueUrl.QueueUrl,
+		receiptHandle: msg.ReceiptHandle,
+	})
+	ch <- &pm
 }
 
 func (m *awsMessaging) readMessages(ctx context.Context, queueResult *sqs.GetQueueUrlOutput) (*sqs.ReceiveMessageOutput, error) {
@@ -114,15 +150,6 @@ func (m *awsMessaging) readMessages(ctx context.Context, queueResult *sqs.GetQue
 	})
 
 	return msgs, err
-}
-
-func (m *awsMessaging) removeMessageFromQueue(ctx context.Context, queueResult *sqs.GetQueueUrlOutput, msg *sqs.Message) {
-	if _, err := m.sqsService.DeleteMessageWithContext(ctx, &sqs.DeleteMessageInput{
-		QueueUrl:      queueResult.QueueUrl,
-		ReceiptHandle: msg.ReceiptHandle,
-	}); err != nil {
-		logging.Error(ctx).Err(err).Msgf(couldNotDeleteMsg, *msg.MessageId, *queueResult.QueueUrl)
-	}
 }
 
 func (m *awsMessaging) getQueueUrl(ctx context.Context, queue string) *sqs.GetQueueUrlOutput {

--- a/pkg/messaging/aws.go
+++ b/pkg/messaging/aws.go
@@ -30,15 +30,14 @@ type awsMessaging struct {
 }
 
 type awsOriginalMessage struct {
-	ctx           context.Context
 	sqsService    *sqs.SQS
 	queueUrl      *string
 	receiptHandle *string
 }
 
 // Ack deletes the message from the queue after successful processing.
-func (a awsOriginalMessage) Ack() error {
-	_, err := a.sqsService.DeleteMessageWithContext(a.ctx, &sqs.DeleteMessageInput{
+func (a awsOriginalMessage) Ack(ctx context.Context) error {
+	_, err := a.sqsService.DeleteMessageWithContext(ctx, &sqs.DeleteMessageInput{
 		QueueUrl:      a.queueUrl,
 		ReceiptHandle: a.receiptHandle,
 	})
@@ -49,12 +48,12 @@ func (a awsOriginalMessage) Ack() error {
 // Nack leaves the message in the queue. With requeue it becomes visible again
 // immediately; otherwise it reappears after the visibility timeout and the
 // queue's redrive policy routes it to the DLQ once maxReceiveCount is exceeded.
-func (a awsOriginalMessage) Nack(requeue bool, _ error) error {
+func (a awsOriginalMessage) Nack(ctx context.Context, requeue bool, _ error) error {
 	if !requeue {
 		return nil
 	}
 
-	_, err := a.sqsService.ChangeMessageVisibilityWithContext(a.ctx, &sqs.ChangeMessageVisibilityInput{
+	_, err := a.sqsService.ChangeMessageVisibilityWithContext(ctx, &sqs.ChangeMessageVisibilityInput{
 		QueueUrl:          a.queueUrl,
 		ReceiptHandle:     a.receiptHandle,
 		VisibilityTimeout: aws.Int64(0),
@@ -133,7 +132,6 @@ func (m *awsMessaging) handleMessage(ctx context.Context, c *consumer, queueUrl 
 	}
 
 	pm.addOriginBrokerNotification(awsOriginalMessage{
-		ctx:           ctx,
 		sqsService:    m.sqsService,
 		queueUrl:      queueUrl.QueueUrl,
 		receiptHandle: msg.ReceiptHandle,

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -1,9 +1,11 @@
 package messaging
 
+import "context"
+
 // OriginalMessage defines the interface for acknowledging or rejecting a message from a message broker.
 type OriginalMessage interface {
 	// Ack acknowledges the message.
-	Ack() error
+	Ack(ctx context.Context) error
 	// Nack rejects the message.
 	// If requeue is true, the message is put back in the original queue for immediate redelivery.
 	// If requeue is false, the message is left to the broker's dead-letter handling:
@@ -12,5 +14,5 @@ type OriginalMessage interface {
 	// redrive policy moves it to the DLQ once maxReceiveCount is exceeded;
 	// GCP Pub/Sub nacks it, so the subscription's retry policy redelivers it until the
 	// dead-letter policy (if configured) forwards it to the dead-letter topic.
-	Nack(requeue bool, err error) error
+	Nack(ctx context.Context, requeue bool, err error) error
 }

--- a/pkg/messaging/broker.go
+++ b/pkg/messaging/broker.go
@@ -5,7 +5,12 @@ type OriginalMessage interface {
 	// Ack acknowledges the message.
 	Ack() error
 	// Nack rejects the message.
-	// If requeue is true, the message will be put back in the original queue.
-	// If requeue is false, the message will be discarded or sent to a DLQ.
+	// If requeue is true, the message is put back in the original queue for immediate redelivery.
+	// If requeue is false, the message is left to the broker's dead-letter handling:
+	// RabbitMQ rejects it without requeue (routed to the configured DLX, or dropped if none);
+	// SQS leaves it in-flight until the visibility timeout expires, after which the queue's
+	// redrive policy moves it to the DLQ once maxReceiveCount is exceeded;
+	// GCP Pub/Sub nacks it, so the subscription's retry policy redelivers it until the
+	// dead-letter policy (if configured) forwards it to the dead-letter topic.
 	Nack(requeue bool, err error) error
 }

--- a/pkg/messaging/consumer.go
+++ b/pkg/messaging/consumer.go
@@ -69,14 +69,14 @@ func processMessage(c *consumer, msg *ProviderMessage) {
 
 	if err := c.fn(ctx, msg); err != nil {
 		logging.Error(ctx).Err(err).Msgf(couldNotProcessMsg, msg.ID)
-		if err := msg.Nack(false, err); err != nil {
+		if err := msg.Nack(ctx, false, err); err != nil {
 			logging.Error(ctx).Err(err).Msgf("error sending nack for message %s", msg.ID)
 		}
 		monitoring.NoticeError(txn, err)
 		return
 	}
 
-	if err := msg.Ack(); err != nil {
+	if err := msg.Ack(ctx); err != nil {
 		logging.Error(ctx).Err(err).Msgf("error sending ack for message %s", msg.ID)
 	}
 

--- a/pkg/messaging/consumer.go
+++ b/pkg/messaging/consumer.go
@@ -40,6 +40,7 @@ func NewConsumer(qc QueueConsumer) {
 	}
 
 	observer.Attach(consumerObserver{c: c})
+	c.Add(1)
 	startListener(c)
 }
 

--- a/pkg/messaging/gcp.go
+++ b/pkg/messaging/gcp.go
@@ -13,13 +13,20 @@ type gcpMessaging struct {
 	client *pubsub.Client
 }
 
-type gcpOriginalMessage struct{}
+type gcpOriginalMessage struct {
+	msg *pubsub.Message
+}
 
+// Ack acknowledges the message after successful processing.
 func (g gcpOriginalMessage) Ack() error {
+	g.msg.Ack()
 	return nil
 }
 
+// Nack rejects the message; the subscription's retry policy redelivers it and the
+// dead-letter policy (if configured) forwards it to the dead-letter topic.
 func (g gcpOriginalMessage) Nack(_ bool, _ error) error {
+	g.msg.Nack()
 	return nil
 }
 
@@ -42,23 +49,28 @@ func (m *gcpMessaging) producer(ctx context.Context, p *Producer, msg *ProviderM
 func (m *gcpMessaging) consumer(ctx context.Context, c *consumer) (chan *ProviderMessage, error) {
 	ch := make(chan *ProviderMessage, 1)
 	sub := m.client.Subscriber(c.queue)
+	sub.ReceiveSettings.MaxOutstandingMessages = 1
+	sub.ReceiveSettings.NumGoroutines = 1
+
+	receiveCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		<-c.done
+		cancel()
+	}()
 
 	go func() {
-		if err := sub.Receive(ctx, func(innerCtx context.Context, msg *pubsub.Message) {
-			if c.isCanceled() {
-				c.Done()
-				return
-			}
+		defer c.Done()
 
+		if err := sub.Receive(receiveCtx, func(_ context.Context, msg *pubsub.Message) {
 			var pm ProviderMessage
 			if err := json.Unmarshal(msg.Data, &pm); err != nil {
 				logging.Error(ctx).Err(err).Msgf(couldNotReadMsgBody, msg.ID, c.queue)
+				msg.Nack()
 				return
 			}
 
-			pm.addOriginBrokerNotification(gcpOriginalMessage{})
+			pm.addOriginBrokerNotification(gcpOriginalMessage{msg: msg})
 			ch <- &pm
-			msg.Ack()
 		}); err != nil {
 			logging.Error(ctx).Err(err).Msgf(couldNotReceiveMsg, c.queue)
 		}

--- a/pkg/messaging/gcp.go
+++ b/pkg/messaging/gcp.go
@@ -52,14 +52,18 @@ func (m *gcpMessaging) consumer(ctx context.Context, c *consumer) (chan *Provide
 	sub.ReceiveSettings.MaxOutstandingMessages = 1
 	sub.ReceiveSettings.NumGoroutines = 1
 
-	receiveCtx, cancel := context.WithCancel(ctx)
-	go func() {
-		<-c.done
-		cancel()
-	}()
-
 	go func() {
 		defer c.Done()
+
+		receiveCtx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		// stop receiving when the consumer is closed; canceling an already
+		// canceled context is a no-op
+		go func() {
+			<-c.done
+			cancel()
+		}()
 
 		if err := sub.Receive(receiveCtx, func(_ context.Context, msg *pubsub.Message) {
 			var pm ProviderMessage

--- a/pkg/messaging/gcp.go
+++ b/pkg/messaging/gcp.go
@@ -18,14 +18,14 @@ type gcpOriginalMessage struct {
 }
 
 // Ack acknowledges the message after successful processing.
-func (g gcpOriginalMessage) Ack() error {
+func (g gcpOriginalMessage) Ack(_ context.Context) error {
 	g.msg.Ack()
 	return nil
 }
 
 // Nack rejects the message; the subscription's retry policy redelivers it and the
 // dead-letter policy (if configured) forwards it to the dead-letter topic.
-func (g gcpOriginalMessage) Nack(_ bool, _ error) error {
+func (g gcpOriginalMessage) Nack(_ context.Context, _ bool, _ error) error {
 	g.msg.Nack()
 	return nil
 }

--- a/pkg/messaging/messaging.go
+++ b/pkg/messaging/messaging.go
@@ -22,7 +22,7 @@ const (
 	couldNotReceiveMsg           string = "error on receive message from queue %s"
 	couldNotProcessMsg           string = "could not process message %s"
 	couldNotReadMsgBody          string = "could not read message body with id %s from queue %s"
-	couldNotDeleteMsg            string = "could not delete message with id %s from queue %s"
+	messagingNotSupported        string = "messaging is not supported for cloud %s"
 	couldNotSendMsg              string = "could not send message with id %s to topic %s"
 	safelyCloseMsg               string = "waiting to safely close messaging module"
 	timeoutCloseMsg              string = "waiting timed out, forcing close the messaging module"
@@ -66,6 +66,11 @@ func Initialize() {
 		case config.CLOUD_GCP, config.CLOUD_FIREBASE:
 			instance = newGcpMessaging()
 		}
+	}
+
+	if instance == nil {
+		logging.Fatal(context.Background()).Msgf(messagingNotSupported, config.CLOUD)
+		return
 	}
 
 	observer.Attach(&messagingObserver{})

--- a/pkg/messaging/messaging_test.go
+++ b/pkg/messaging/messaging_test.go
@@ -222,16 +222,16 @@ func awsNackRequeueTest(t *testing.T) {
 	}
 
 	first := awsReceiveOne(t, sqsClient, queue.QueueUrl)
-	om := awsOriginalMessage{ctx: context.Background(), sqsService: sqsClient, queueUrl: queue.QueueUrl, receiptHandle: first.ReceiptHandle}
+	om := awsOriginalMessage{sqsService: sqsClient, queueUrl: queue.QueueUrl, receiptHandle: first.ReceiptHandle}
 
-	assert.NoError(t, om.Nack(false, nil), "nack without requeue should be a no-op")
-	assert.NoError(t, om.Nack(true, nil), "nack with requeue should reset the visibility timeout")
+	assert.NoError(t, om.Nack(context.Background(), false, nil), "nack without requeue should be a no-op")
+	assert.NoError(t, om.Nack(context.Background(), true, nil), "nack with requeue should reset the visibility timeout")
 
 	// after nack with requeue the message must be receivable again long before
 	// the 60s visibility timeout set on the first receive expires
 	second := awsReceiveOne(t, sqsClient, queue.QueueUrl)
-	om = awsOriginalMessage{ctx: context.Background(), sqsService: sqsClient, queueUrl: queue.QueueUrl, receiptHandle: second.ReceiptHandle}
-	assert.NoError(t, om.Ack())
+	om = awsOriginalMessage{sqsService: sqsClient, queueUrl: queue.QueueUrl, receiptHandle: second.ReceiptHandle}
+	assert.NoError(t, om.Ack(context.Background()))
 }
 
 func awsReceiveOne(t *testing.T, sqsClient *sqs.SQS, queueUrl *string) *sqs.Message {

--- a/pkg/messaging/messaging_test.go
+++ b/pkg/messaging/messaging_test.go
@@ -152,27 +152,7 @@ func executeMessagingTest(t *testing.T, opts messagingProviderOpts) {
 		var invocations atomic.Int32
 
 		qc := queueConsumerTest{
-			fn: func(ctx context.Context, message *ProviderMessage) error {
-				n := invocations.Add(1)
-
-				if opts.redelivers {
-					// first delivery fails; the broker must redeliver so the second succeeds
-					if n == 1 {
-						return fmt.Errorf("email not valid")
-					}
-					if n == 2 {
-						close(done)
-					}
-					return nil
-				}
-
-				// terminal nack (RabbitMQ): a failed handler routes the message straight
-				// to the DLX, so it must be invoked exactly once and never redelivered
-				if n == 1 {
-					close(done)
-				}
-				return fmt.Errorf("email not valid")
-			},
+			fn:    settleHandler(opts.redelivers, &invocations, done),
 			qName: testFailQueueName,
 		}
 
@@ -194,19 +174,52 @@ func executeMessagingTest(t *testing.T, opts messagingProviderOpts) {
 			t.Fatalf("Test didn't finish after %s (invocations: %d)", opts.waitTimeout, invocations.Load())
 		}
 
-		if opts.redelivers {
-			assert.GreaterOrEqual(t, invocations.Load(), int32(2), "failed message should have been redelivered")
-			if opts.assertDLQ != nil {
-				// only the poison message dead-letters; the valid one succeeded on redelivery
-				opts.assertDLQ(t, 1)
-			}
-		} else if opts.assertDLQ != nil {
-			// poison message + failed valid message are both routed to the DLQ
-			opts.assertDLQ(t, 2)
-
-			assert.Equal(t, int32(1), invocations.Load(), "terminal nack should not redeliver")
-		}
+		assertFailedMessageSettlement(t, opts, invocations.Load())
 	})
+}
+
+// settleHandler returns a consumer handler that fails the first delivery. With
+// redelivery semantics the second delivery succeeds and closes done; with
+// terminal-nack semantics every delivery fails and done closes on the first call.
+func settleHandler(redelivers bool, invocations *atomic.Int32, done chan struct{}) func(context.Context, *ProviderMessage) error {
+	return func(_ context.Context, _ *ProviderMessage) error {
+		n := invocations.Add(1)
+
+		if !redelivers {
+			// terminal nack (RabbitMQ): a failed handler routes the message straight
+			// to the DLX, so it must be invoked exactly once and never redelivered
+			if n == 1 {
+				close(done)
+			}
+			return fmt.Errorf("email not valid")
+		}
+
+		// first delivery fails; the broker must redeliver so the second succeeds
+		switch n {
+		case 1:
+			return fmt.Errorf("email not valid")
+		case 2:
+			close(done)
+		}
+		return nil
+	}
+}
+
+func assertFailedMessageSettlement(t *testing.T, opts messagingProviderOpts, invocations int32) {
+	if opts.redelivers {
+		assert.GreaterOrEqual(t, invocations, int32(2), "failed message should have been redelivered")
+		if opts.assertDLQ != nil {
+			// only the poison message dead-letters; the valid one succeeded on redelivery
+			opts.assertDLQ(t, 1)
+		}
+		return
+	}
+
+	if opts.assertDLQ != nil {
+		// poison message + failed valid message are both routed to the DLQ
+		opts.assertDLQ(t, 2)
+		assert.Equal(t, int32(1), invocations, "terminal nack should not redeliver")
+	}
 }
 
 func awsNackRequeueTest(t *testing.T) {

--- a/pkg/messaging/messaging_test.go
+++ b/pkg/messaging/messaging_test.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"cloud.google.com/go/pubsub/v2"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sns"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/cloud"
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/config"
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/logging"
+	amqp "github.com/rabbitmq/amqp091-go"
 
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/test"
 	"github.com/stretchr/testify/assert"
@@ -39,13 +46,30 @@ func (q *queueConsumerTest) QueueName() string {
 	return q.qName
 }
 
+// messagingProviderOpts carries the provider-specific hooks and expectations
+// for the shared messaging test suite.
+type messagingProviderOpts struct {
+	// publishRaw publishes raw bytes to the topic, bypassing the ProviderMessage envelope
+	publishRaw func(t *testing.T, topic string, body []byte)
+	// assertDLQ waits until the fail-queue DLQ holds at least min messages; nil skips the check
+	assertDLQ func(t *testing.T, min int)
+	// redelivers is true when Nack(false) causes redelivery (AWS visibility timeout, GCP retry
+	// policy) and false when it routes the message straight to the DLQ (RabbitMQ DLX)
+	redelivers  bool
+	waitTimeout time.Duration
+}
+
 func TestMessaging(t *testing.T) {
 	logging.Initialize()
 
 	t.Run("TestMessaging_GCP", func(t *testing.T) {
 		test.InitializeGcpEmulator()
 		Initialize()
-		executeMessagingTest(t)
+		executeMessagingTest(t, messagingProviderOpts{
+			publishRaw:  gcpPublishRaw,
+			redelivers:  true,
+			waitTimeout: 15 * time.Second,
+		})
 		t.Cleanup(func() {
 			instance = nil
 			logging.Info(context.Background()).Msg("Cleaning up GCP emulator")
@@ -55,7 +79,12 @@ func TestMessaging(t *testing.T) {
 	t.Run("TestMessaging_AWS", func(t *testing.T) {
 		test.InitializeTestLocalstack()
 		Initialize()
-		executeMessagingTest(t)
+		executeMessagingTest(t, messagingProviderOpts{
+			publishRaw:  awsPublishRaw,
+			assertDLQ:   awsAssertDLQ,
+			redelivers:  true,
+			waitTimeout: 15 * time.Second,
+		})
 		t.Cleanup(func() {
 			instance = nil
 			logging.Info(context.Background()).Msg("Cleaning up AWS localstack")
@@ -65,7 +94,12 @@ func TestMessaging(t *testing.T) {
 	t.Run("TestMessaging_RabbitMQ", func(t *testing.T) {
 		test.InitializeRabbitmq()
 		Initialize()
-		executeMessagingTest(t)
+		executeMessagingTest(t, messagingProviderOpts{
+			publishRaw:  rabbitmqPublishRaw,
+			assertDLQ:   rabbitmqAssertDLQ,
+			redelivers:  false,
+			waitTimeout: 15 * time.Second,
+		})
 		t.Cleanup(func() {
 			instance = nil
 			_ = os.Unsetenv("RABBITMQ_URL")
@@ -76,7 +110,7 @@ func TestMessaging(t *testing.T) {
 	})
 }
 
-func executeMessagingTest(t *testing.T) {
+func executeMessagingTest(t *testing.T, opts messagingProviderOpts) {
 
 	t.Run("Should return nil when process message with success", func(t *testing.T) {
 		chSuccess := make(chan string)
@@ -112,13 +146,31 @@ func executeMessagingTest(t *testing.T) {
 		}
 	})
 
-	t.Run("Should return error when process message with error and send message to dlq", func(t *testing.T) {
-		chFail := make(chan string)
+	t.Run("Should survive poison message and settle failed message according to broker semantics", func(t *testing.T) {
+		done := make(chan struct{})
+		var invocations atomic.Int32
+
 		qc := queueConsumerTest{
 			fn: func(ctx context.Context, message *ProviderMessage) error {
-				err := fmt.Errorf("email not valid")
-				chFail <- err.Error()
-				return err
+				n := invocations.Add(1)
+
+				if opts.redelivers {
+					// first delivery fails; the broker must redeliver so the second succeeds
+					if n == 1 {
+						return fmt.Errorf("email not valid")
+					}
+					if n == 2 {
+						close(done)
+					}
+					return nil
+				}
+
+				// terminal nack (RabbitMQ): a failed handler routes the message straight
+				// to the DLX, so it must be invoked exactly once and never redelivered
+				if n == 1 {
+					close(done)
+				}
+				return fmt.Errorf("email not valid")
 			},
 			qName: testFailQueueName,
 		}
@@ -127,17 +179,141 @@ func executeMessagingTest(t *testing.T) {
 
 		NewConsumer(&qc)
 
+		// a malformed payload must be skipped/rejected without killing the consumer loop
+		opts.publishRaw(t, testFailTopicName, []byte("this is not a valid provider message"))
+
 		model := userMessageTest{"User Name", "user@email.com"}
 		if err := producer.Publish(context.Background(), "create", model); err != nil {
 			t.Fatal(err)
 		}
 
-		timeout := time.After(2 * time.Second)
 		select {
-		case msgDLQ := <-chFail:
-			assert.Equal(t, "email not valid", msgDLQ)
-		case <-timeout:
-			t.Fatal("Test didn't finish after 2s")
+		case <-done:
+		case <-time.After(opts.waitTimeout):
+			t.Fatalf("Test didn't finish after %s (invocations: %d)", opts.waitTimeout, invocations.Load())
+		}
+
+		if opts.redelivers {
+			assert.GreaterOrEqual(t, invocations.Load(), int32(2), "failed message should have been redelivered")
+			if opts.assertDLQ != nil {
+				// only the poison message dead-letters; the valid one succeeded on redelivery
+				opts.assertDLQ(t, 1)
+			}
+		} else if opts.assertDLQ != nil {
+			// poison message + failed valid message are both routed to the DLQ
+			opts.assertDLQ(t, 2)
+
+			assert.Equal(t, int32(1), invocations.Load(), "terminal nack should not redeliver")
 		}
 	})
+}
+
+func awsPublishRaw(t *testing.T, topic string, body []byte) {
+	snsClient := sns.New(cloud.GetAwsSession())
+	topicArn := fmt.Sprintf("arn:%s:sns:%s:%s:%s",
+		cloud.GetAwsARN().Partition,
+		*cloud.GetAwsSession().Config.Region,
+		cloud.GetAwsARN().AccountID,
+		topic,
+	)
+
+	if _, err := snsClient.Publish(&sns.PublishInput{
+		Message:  aws.String(string(body)),
+		TopicArn: aws.String(topicArn),
+	}); err != nil {
+		t.Fatalf("could not publish raw message to topic %s: %v", topic, err)
+	}
+}
+
+func awsAssertDLQ(t *testing.T, min int) {
+	sqsClient := sqs.New(cloud.GetAwsSession())
+	queueUrl, err := sqsClient.GetQueueUrl(&sqs.GetQueueUrlInput{
+		QueueName: aws.String(testFailQueueName + "_DLQ"),
+	})
+	if err != nil {
+		t.Fatalf("could not get DLQ url: %v", err)
+	}
+
+	received := 0
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := sqsClient.ReceiveMessage(&sqs.ReceiveMessageInput{
+			QueueUrl:            queueUrl.QueueUrl,
+			MaxNumberOfMessages: aws.Int64(10),
+			WaitTimeSeconds:     aws.Int64(1),
+		})
+		if err == nil {
+			received += len(out.Messages)
+		}
+		if received >= min {
+			return
+		}
+	}
+
+	t.Fatalf("expected at least %d messages in DLQ, got %d", min, received)
+}
+
+func gcpPublishRaw(t *testing.T, topic string, body []byte) {
+	ctx := context.Background()
+	client, err := pubsub.NewClient(ctx, os.Getenv("PUBSUB_PROJECT_ID"))
+	if err != nil {
+		t.Fatalf("could not create pubsub client: %v", err)
+	}
+	defer client.Close()
+
+	if _, err := client.Publisher(topic).Publish(ctx, &pubsub.Message{Data: body}).Get(ctx); err != nil {
+		t.Fatalf("could not publish raw message to topic %s: %v", topic, err)
+	}
+}
+
+func rabbitmqPublishRaw(t *testing.T, topic string, body []byte) {
+	conn, err := amqp.Dial(os.Getenv(rabbitMQURLEnvVar))
+	if err != nil {
+		t.Fatalf("could not connect to rabbitmq: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("could not open rabbitmq channel: %v", err)
+	}
+	defer ch.Close()
+
+	if err := ch.PublishWithContext(context.Background(), topic, topic, false, false, amqp.Publishing{
+		ContentType: "application/json",
+		Body:        body,
+	}); err != nil {
+		t.Fatalf("could not publish raw message to topic %s: %v", topic, err)
+	}
+}
+
+func rabbitmqAssertDLQ(t *testing.T, min int) {
+	conn, err := amqp.Dial(os.Getenv(rabbitMQURLEnvVar))
+	if err != nil {
+		t.Fatalf("could not connect to rabbitmq: %v", err)
+	}
+	defer conn.Close()
+
+	ch, err := conn.Channel()
+	if err != nil {
+		t.Fatalf("could not open rabbitmq channel: %v", err)
+	}
+	defer ch.Close()
+
+	var count int
+	deadline := time.Now().Add(20 * time.Second)
+	for time.Now().Before(deadline) {
+		q, err := ch.QueueDeclarePassive(testFailQueueName+".dlq", true, false, false, false, nil)
+		if err != nil {
+			t.Fatalf("could not inspect DLQ: %v", err)
+		}
+
+		count = q.Messages
+		if count >= min {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	t.Fatalf("expected at least %d messages in DLQ, got %d", min, count)
 }

--- a/pkg/messaging/messaging_test.go
+++ b/pkg/messaging/messaging_test.go
@@ -85,6 +85,7 @@ func TestMessaging(t *testing.T) {
 			redelivers:  true,
 			waitTimeout: 15 * time.Second,
 		})
+		t.Run("Should make message immediately visible when nack with requeue", awsNackRequeueTest)
 		t.Cleanup(func() {
 			instance = nil
 			logging.Info(context.Background()).Msg("Cleaning up AWS localstack")
@@ -206,6 +207,52 @@ func executeMessagingTest(t *testing.T, opts messagingProviderOpts) {
 			assert.Equal(t, int32(1), invocations.Load(), "terminal nack should not redeliver")
 		}
 	})
+}
+
+func awsNackRequeueTest(t *testing.T) {
+	sqsClient := sqs.New(cloud.GetAwsSession())
+
+	queue, err := sqsClient.CreateQueue(&sqs.CreateQueueInput{QueueName: aws.String("COLIBRI_PROJECT_NACK_REQUEUE_TEST")})
+	if err != nil {
+		t.Fatalf("could not create queue: %v", err)
+	}
+
+	if _, err = sqsClient.SendMessage(&sqs.SendMessageInput{QueueUrl: queue.QueueUrl, MessageBody: aws.String("{}")}); err != nil {
+		t.Fatalf("could not send message: %v", err)
+	}
+
+	first := awsReceiveOne(t, sqsClient, queue.QueueUrl)
+	om := awsOriginalMessage{ctx: context.Background(), sqsService: sqsClient, queueUrl: queue.QueueUrl, receiptHandle: first.ReceiptHandle}
+
+	assert.NoError(t, om.Nack(false, nil), "nack without requeue should be a no-op")
+	assert.NoError(t, om.Nack(true, nil), "nack with requeue should reset the visibility timeout")
+
+	// after nack with requeue the message must be receivable again long before
+	// the 60s visibility timeout set on the first receive expires
+	second := awsReceiveOne(t, sqsClient, queue.QueueUrl)
+	om = awsOriginalMessage{ctx: context.Background(), sqsService: sqsClient, queueUrl: queue.QueueUrl, receiptHandle: second.ReceiptHandle}
+	assert.NoError(t, om.Ack())
+}
+
+func awsReceiveOne(t *testing.T, sqsClient *sqs.SQS, queueUrl *string) *sqs.Message {
+	deadline := time.Now().Add(10 * time.Second)
+	for time.Now().Before(deadline) {
+		out, err := sqsClient.ReceiveMessage(&sqs.ReceiveMessageInput{
+			QueueUrl:            queueUrl,
+			MaxNumberOfMessages: aws.Int64(1),
+			WaitTimeSeconds:     aws.Int64(2),
+			VisibilityTimeout:   aws.Int64(60),
+		})
+		if err != nil {
+			t.Fatalf("could not receive message: %v", err)
+		}
+		if len(out.Messages) > 0 {
+			return out.Messages[0]
+		}
+	}
+
+	t.Fatal("no message received before deadline")
+	return nil
 }
 
 func awsPublishRaw(t *testing.T, topic string, body []byte) {

--- a/pkg/messaging/messaging_unit_test.go
+++ b/pkg/messaging/messaging_unit_test.go
@@ -1,0 +1,89 @@
+package messaging
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sqs"
+	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/config"
+	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/logging"
+	amqp "github.com/rabbitmq/amqp091-go"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestInitializeUnsupportedCloud(t *testing.T) {
+	t.Run("Should panic when cloud provider has no messaging support", func(t *testing.T) {
+		logging.Initialize()
+
+		previousInstance := instance
+		previousCloud := config.CLOUD
+		previousMessaging := config.COLIBRI_MESSAGING
+		t.Cleanup(func() {
+			instance = previousInstance
+			config.CLOUD = previousCloud
+			config.COLIBRI_MESSAGING = previousMessaging
+		})
+
+		instance = nil
+		config.CLOUD = config.CLOUD_NONE
+		config.COLIBRI_MESSAGING = config.MESSAGING_CLOUD_DEFAULT
+
+		assert.Panics(t, func() { Initialize() })
+	})
+}
+
+func TestAwsHandleMessage(t *testing.T) {
+	t.Run("Should skip message when body is not a valid notification", func(t *testing.T) {
+		m := &awsMessaging{}
+		c := &consumer{queue: "test-queue", done: make(chan any)}
+		ch := make(chan *ProviderMessage, 1)
+
+		m.handleMessage(context.Background(), c, &sqs.GetQueueUrlOutput{}, &sqs.Message{
+			MessageId: aws.String("msg-1"),
+			Body:      aws.String("this is not a json body"),
+		}, ch)
+
+		assert.Empty(t, ch)
+	})
+}
+
+func TestRabbitMQProcessMessages(t *testing.T) {
+	m := &rabbitMQMessaging{}
+
+	t.Run("Should stop when consumer is closed", func(t *testing.T) {
+		c := &consumer{queue: "test-queue", done: make(chan any)}
+		msgs := make(chan amqp.Delivery)
+		out := make(chan *ProviderMessage, 1)
+
+		c.Add(1)
+		close(c.done)
+		m.processMessages(context.Background(), c, msgs, out)
+
+		assert.Empty(t, out)
+	})
+
+	t.Run("Should stop when delivery channel closes", func(t *testing.T) {
+		c := &consumer{queue: "test-queue", done: make(chan any)}
+		msgs := make(chan amqp.Delivery)
+		out := make(chan *ProviderMessage, 1)
+
+		c.Add(1)
+		close(msgs)
+		m.processMessages(context.Background(), c, msgs, out)
+
+		assert.Empty(t, out)
+	})
+}
+
+func TestRabbitMQHandleUnmarshalError(t *testing.T) {
+	t.Run("Should not panic when reject fails", func(t *testing.T) {
+		m := &rabbitMQMessaging{}
+		c := &consumer{queue: "test-queue", done: make(chan any)}
+
+		assert.NotPanics(t, func() {
+			m.handleUnmarshalError(context.Background(), c, amqp.Delivery{MessageId: "msg-1"}, errors.New("invalid body"))
+		})
+	})
+}

--- a/pkg/messaging/provider_message.go
+++ b/pkg/messaging/provider_message.go
@@ -69,9 +69,9 @@ func (msg *ProviderMessage) addOriginBrokerNotification(n any) {
 }
 
 // Ack acknowledges the message.
-func (msg *ProviderMessage) Ack() error {
+func (msg *ProviderMessage) Ack(ctx context.Context) error {
 	if originalMessage, ok := msg.n.(OriginalMessage); ok {
-		return originalMessage.Ack()
+		return originalMessage.Ack(ctx)
 	}
 	return nil
 }
@@ -79,9 +79,9 @@ func (msg *ProviderMessage) Ack() error {
 // Nack rejects the message.
 // If requeue is true, the message will be put back in the original queue.
 // If requeue is false, the message will be discarded or sent to a DLQ.
-func (msg *ProviderMessage) Nack(requeue bool, err error) error {
+func (msg *ProviderMessage) Nack(ctx context.Context, requeue bool, err error) error {
 	if originalMessage, ok := msg.n.(OriginalMessage); ok {
-		return originalMessage.Nack(requeue, err)
+		return originalMessage.Nack(ctx, requeue, err)
 	}
 	return nil
 }

--- a/pkg/messaging/rabbitmq.go
+++ b/pkg/messaging/rabbitmq.go
@@ -26,11 +26,11 @@ type rabbitMQOriginalMessage struct {
 	d amqp.Delivery
 }
 
-func (r rabbitMQOriginalMessage) Ack() error {
+func (r rabbitMQOriginalMessage) Ack(_ context.Context) error {
 	return r.d.Ack(false)
 }
 
-func (r rabbitMQOriginalMessage) Nack(requeue bool, _ error) error {
+func (r rabbitMQOriginalMessage) Nack(_ context.Context, requeue bool, _ error) error {
 	return r.d.Reject(requeue)
 }
 

--- a/pkg/messaging/rabbitmq.go
+++ b/pkg/messaging/rabbitmq.go
@@ -13,10 +13,8 @@ import (
 const (
 	rabbitMQDefaultURL = "amqp://guest:guest@localhost:5672/"
 	rabbitMQURLEnvVar  = "RABBITMQ_URL"
-	dlqExchangeSuffix  = "dlx"
 
-	couldNotSendToDLQ = "could not send message %s to DLQ"
-	messageSentToDLQ  = "message %s sent to DLQ %s due to: %s"
+	messageRejectedToDLQ = "message %s from queue %s rejected without requeue due to: %s"
 )
 
 type rabbitMQMessaging struct {
@@ -25,9 +23,7 @@ type rabbitMQMessaging struct {
 }
 
 type rabbitMQOriginalMessage struct {
-	m *rabbitMQMessaging
 	d amqp.Delivery
-	q string
 }
 
 func (r rabbitMQOriginalMessage) Ack() error {
@@ -114,12 +110,21 @@ func (m *rabbitMQMessaging) startConsuming(queueName string) (<-chan amqp.Delive
 	)
 }
 
-// processMessages handles incoming messages from RabbitMQ
+// processMessages handles incoming messages from RabbitMQ until the delivery
+// channel closes or the consumer is canceled
 func (m *rabbitMQMessaging) processMessages(ctx context.Context, c *consumer, msgs <-chan amqp.Delivery, providerMsgs chan<- *ProviderMessage) {
 	defer c.Done()
 
-	for d := range msgs {
-		m.handleMessage(ctx, c, d, providerMsgs)
+	for {
+		select {
+		case <-c.done:
+			return
+		case d, ok := <-msgs:
+			if !ok {
+				return
+			}
+			m.handleMessage(ctx, c, d, providerMsgs)
+		}
 	}
 }
 
@@ -132,16 +137,17 @@ func (m *rabbitMQMessaging) handleMessage(ctx context.Context, c *consumer, d am
 		return
 	}
 
-	pm.addOriginBrokerNotification(rabbitMQOriginalMessage{m: m, d: d, q: c.queue})
+	pm.addOriginBrokerNotification(rabbitMQOriginalMessage{d: d})
 	providerMsgs <- &pm
 }
 
-// handleUnmarshalError handles errors when unmarshalling a message
+// handleUnmarshalError rejects a malformed message without requeue so the broker
+// routes it to the configured DLX instead of redelivering or dropping it silently
 func (m *rabbitMQMessaging) handleUnmarshalError(ctx context.Context, c *consumer, d amqp.Delivery, err error) {
 	logging.Error(ctx).Err(err).Msgf(couldNotReadMsgBody, d.MessageId, c.queue)
 
-	logging.Debug(ctx).Msgf(messageSentToDLQ, d.MessageId, c.queue, err.Error())
-	if ackErr := d.Ack(false); ackErr != nil {
-		logging.Error(ctx).Err(ackErr).Msgf("Could not ack message %s after DLQ", d.MessageId)
+	logging.Debug(ctx).Msgf(messageRejectedToDLQ, d.MessageId, c.queue, err.Error())
+	if rejectErr := d.Reject(false); rejectErr != nil {
+		logging.Error(ctx).Err(rejectErr).Msgf("could not reject message %s", d.MessageId)
 	}
 }

--- a/pkg/web/restclient/client_test.go
+++ b/pkg/web/restclient/client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/base/test"
 	"github.com/colibriproject-dev/colibri-sdk-go/pkg/database/cacheDB"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type userResponseTestStruct struct {
@@ -97,6 +98,7 @@ func TestGet(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusOK, response.StatusCode())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, 5, len(*response.SuccessBody()))
 		assert.EqualValues(t, expected, *response.SuccessBody())
 		assert.Nil(t, response.ErrorBody())
@@ -137,7 +139,7 @@ func TestPost(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusCreated, response.StatusCode())
-		assert.NotNil(t, response.SuccessBody())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, uint(10), response.SuccessBody().ID)
 		assert.Equal(t, newUser.Name, response.SuccessBody().Name)
 		assert.Equal(t, newUser.Email, response.SuccessBody().Email)
@@ -231,7 +233,7 @@ func TestPostWithMultipart(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusCreated, response.StatusCode())
-		assert.NotNil(t, response.SuccessBody())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, uint(10), response.SuccessBody().ID)
 		assert.Equal(t, newUser.Name, response.SuccessBody().Name)
 		assert.Equal(t, newUser.Email, response.SuccessBody().Email)
@@ -277,7 +279,7 @@ func TestPut(t *testing.T) {
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusOK, response.StatusCode())
 		assert.NoError(t, response.Error())
-		assert.NotNil(t, response.SuccessBody())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, newUser.ID, response.SuccessBody().ID)
 		assert.Equal(t, newUser.Name, response.SuccessBody().Name)
 		assert.Equal(t, newUser.Email, response.SuccessBody().Email)
@@ -318,7 +320,7 @@ func TestPatch(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusOK, response.StatusCode())
-		assert.NotNil(t, response.SuccessBody())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, uint(10), response.SuccessBody().ID)
 		assert.Equal(t, newUser.Name, response.SuccessBody().Name)
 		assert.NotNil(t, response.SuccessBody().Email)
@@ -359,7 +361,7 @@ func TestDelete(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusOK, response.StatusCode())
-		assert.NotNil(t, response.SuccessBody())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, uint(11), response.SuccessBody().ID)
 		assert.Equal(t, "User 11 deleted", response.SuccessBody().Name)
 		assert.Nil(t, response.ErrorBody())
@@ -419,6 +421,7 @@ func TestPostNotEmptyResponseBodyError(t *testing.T) {
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusInternalServerError, response.StatusCode())
 		assert.Nil(t, response.SuccessBody())
+		require.NotNil(t, response.ErrorBody())
 		assert.EqualValues(t, "Error message post user", response.ErrorBody().Message)
 		assert.EqualError(t, response.Error(), "error body decoded with 500 status code")
 	})
@@ -460,7 +463,7 @@ func TestPostWithBodyString(t *testing.T) {
 
 		assert.NotNil(t, response)
 		assert.EqualValues(t, http.StatusOK, response.StatusCode())
-		assert.NotNil(t, response.SuccessBody())
+		require.NotNil(t, response.SuccessBody())
 		assert.Equal(t, uint(100), response.SuccessBody().ID)
 		assert.Equal(t, "user_100@email.com", response.SuccessBody().Email)
 		assert.Equal(t, "User 100", response.SuccessBody().Name)


### PR DESCRIPTION
  Ack/Nack now settle messages only after the handler runs on AWS/GCP (previously confirmed on receive, losing failed messages). Poison messages are nacked without requeue so broker DLQ config applies, fixes AWS consumer goroutine death on unmarshal error and the unbalanced consumer WaitGroup on shutdown.