### PR TITLE
chore: modernize Go code with go fix

### DIFF
--- a/pkg/base/monitoring/colibri-otel/open_telemetry.go
+++ b/pkg/base/monitoring/colibri-otel/open_telemetry.go
@@ -32,8 +32,8 @@ import (
 // an OTLP endpoint, leaving just host:port as expected by WithEndpoint options.
 func normalizeEndpoint(endpoint string) string {
 	for _, scheme := range []string{"https://", "http://"} {
-		if strings.HasPrefix(endpoint, scheme) {
-			endpoint = strings.TrimPrefix(endpoint, scheme)
+		if after, ok := strings.CutPrefix(endpoint, scheme); ok {
+			endpoint = after
 			break
 		}
 	}

--- a/pkg/base/observer/single_wait_group_test.go
+++ b/pkg/base/observer/single_wait_group_test.go
@@ -12,7 +12,7 @@ import (
 func TestGetWaitGroup(t *testing.T) {
 	resetRunning(t)
 
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		GetWaitGroup()
 	}
 	wg := GetWaitGroup()
@@ -26,7 +26,7 @@ func TestGetWaitGroupShouldReturnSameInstance(t *testing.T) {
 	resetRunning(t)
 
 	wg1 := GetWaitGroup()
-	for i := 0; i < 10; i++ {
+	for range 10 {
 		GetWaitGroup()
 	}
 	wg2 := GetWaitGroup()
@@ -41,12 +41,10 @@ func TestWaitGroup(t *testing.T) {
 
 	var work sync.WaitGroup
 	for i := 0; i <= 50; i++ {
-		work.Add(1)
-		go func() {
-			defer work.Done()
+		work.Go(func() {
 			process(1)
 			process(1)
-		}()
+		})
 	}
 
 	if WaitRunningTimeout() {
@@ -163,13 +161,11 @@ func TestWaitRunningTimeout(t *testing.T) {
 
 	var work sync.WaitGroup
 	for i := 0; i <= 50; i++ {
-		work.Add(1)
-		go func() {
-			defer work.Done()
+		work.Go(func() {
 			process(1)
 			process(2)
 			process(3)
-		}()
+		})
 	}
 	// the work outlives the wait on purpose, so it has to be joined before the test returns
 	t.Cleanup(work.Wait)
@@ -197,7 +193,7 @@ func TestGetWaitGroupConcurrent(t *testing.T) {
 	done.Add(goroutines)
 
 	instances := make([]*sync.WaitGroup, goroutines)
-	for i := 0; i < goroutines; i++ {
+	for i := range goroutines {
 		go func(idx int) {
 			defer done.Done()
 			start.Wait()

--- a/pkg/base/observer/subject_test.go
+++ b/pkg/base/observer/subject_test.go
@@ -112,7 +112,7 @@ func TestSubjectNotifyRunsTheShutdownPipeline(t *testing.T) {
 			DoneRunning()
 		}()
 
-		for i := 0; i < observers; i++ {
+		for i := range observers {
 			Attach(phasedObserverTest{name: fmt.Sprintf("module%d", i), seq: seq, stopped: &stopped})
 		}
 
@@ -155,7 +155,7 @@ func TestSubjectNotifyRunsTheShutdownPipeline(t *testing.T) {
 		t.Cleanup(DoneRunning)
 
 		var closed atomic.Int32
-		for i := 0; i < observers; i++ {
+		for range observers {
 			Attach(closingCounterObserverTest{closed: &closed})
 		}
 

--- a/pkg/di/container.go
+++ b/pkg/di/container.go
@@ -111,8 +111,7 @@ func (c *Container) searchInjectableDependencies(paramType reflect.Type, returnT
 func (c *Container) searchTypes(paramType reflect.Type) []DependencyBean {
 	dependenciesFound := []DependencyBean{}
 	for fnName, dependency := range c.dependencies {
-		for i := 0; i < dependency.constructorType.NumOut(); i++ {
-			returnType := dependency.constructorType.Out(i)
+		for returnType := range dependency.constructorType.Outs() {
 			if returnType == paramType {
 				fmt.Println("parameter: ", paramType, " compatible => ", fnName, " type ", returnType)
 				dependenciesFound = append(dependenciesFound, dependency)
@@ -125,8 +124,7 @@ func (c *Container) searchTypes(paramType reflect.Type) []DependencyBean {
 func (c *Container) searchImplementations(paramType reflect.Type) []DependencyBean {
 	dependenciesFound := []DependencyBean{}
 	for fnName, dependency := range c.dependencies {
-		for i := 0; i < dependency.constructorType.NumOut(); i++ {
-			returnType := dependency.constructorType.Out(i)
+		for returnType := range dependency.constructorType.Outs() {
 			implements := implementsInterface(returnType, paramType)
 			if implements {
 				fmt.Println("parameter: ", paramType, " implementation => ", fnName, " type ", returnType)

--- a/pkg/di/utils.go
+++ b/pkg/di/utils.go
@@ -47,8 +47,8 @@ func getFunctionName(i reflect.Value) string {
 
 func getParamTypes(fnType reflect.Type) []reflect.Type {
 	var paramTypes []reflect.Type
-	for i := 0; i < fnType.NumIn(); i++ {
-		paramTypes = append(paramTypes, fnType.In(i))
+	for in := range fnType.Ins() {
+		paramTypes = append(paramTypes, in)
 	}
 	return paramTypes
 }
@@ -87,7 +87,7 @@ func getTagsInType(objectType reflect.Type, tagName string) map[string]string {
 		message := fmt.Sprintf("struct %v with more than one constructor and no values to disqualify", objectType)
 		panic(message)
 	}
-	for i := 0; i < numField; i++ {
+	for i := range numField {
 		field := objectType.Field(i)
 		// get tag metadata
 		tagValue := field.Tag.Get(tagName)

--- a/pkg/messaging/aws.go
+++ b/pkg/messaging/aws.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"strconv"
 	"time"
 
@@ -103,11 +104,7 @@ func (m *awsMessaging) consumer(ctx context.Context, c *consumer) (chan *Provide
 	// the poll is part of what Close waits for. A poll left running behind a closed consumer
 	// keeps receiving from the queue, and every message it takes is one the next consumer on
 	// that queue never sees
-	c.Add(1)
-
-	go func() {
-		defer c.Done()
-
+	c.Go(func() {
 		for {
 			if c.isCanceled() {
 				return
@@ -144,7 +141,7 @@ func (m *awsMessaging) consumer(ctx context.Context, c *consumer) (chan *Provide
 
 			m.handleMessage(ctx, c, queueUrl, &msgs.Messages[0], ch)
 		}
-	}()
+	})
 
 	return ch, nil
 }
@@ -206,9 +203,7 @@ func (m *awsMessaging) handleMessage(ctx context.Context, c *consumer, queueUrl 
 // into a single string map so consumers can read broker metadata uniformly.
 func awsAttributes(msg *sqstypes.Message) map[string]string {
 	attrs := make(map[string]string, len(msg.Attributes)+len(msg.MessageAttributes))
-	for k, v := range msg.Attributes {
-		attrs[k] = v
-	}
+	maps.Copy(attrs, msg.Attributes)
 	for k, v := range msg.MessageAttributes {
 		if v.StringValue != nil {
 			attrs[k] = *v.StringValue

--- a/pkg/messaging/consumer_test.go
+++ b/pkg/messaging/consumer_test.go
@@ -279,7 +279,7 @@ func TestConsumerProcessesSequentially(t *testing.T) {
 		f.ch <- NewConsumerMessage("test", nil, nil, nil)
 		f.ch <- NewConsumerMessage("test", nil, nil, nil)
 
-		for i := 0; i < 2; i++ {
+		for i := range 2 {
 			select {
 			case <-processed:
 			case <-time.After(time.Second):
@@ -705,7 +705,7 @@ func TestConsumerLeavesTheRegistryWhenItStops(t *testing.T) {
 	t.Run("Should not accumulate consumers that already stopped", func(t *testing.T) {
 		setupMessagingTest(t)
 
-		for i := 0; i < 5; i++ {
+		for i := range 5 {
 			h, err := NewConsumerWithError(&testProducerConsumer{
 				queueName: fmt.Sprintf("recycled-queue-%d", i),
 				fn:        func(_ context.Context, _ *ProviderMessage) error { return nil },
@@ -758,7 +758,7 @@ func TestTestProducerReleasesItsConsumer(t *testing.T) {
 	t.Run("Should not accumulate consumers across executions", func(t *testing.T) {
 		openModule(moduleInstance())
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			producer := NewTestProducer[string](func() error { return nil },
 				fmt.Sprintf("test-producer-repeat-queue-%d", i), 1)
 

--- a/pkg/messaging/messaging_unit_test.go
+++ b/pkg/messaging/messaging_unit_test.go
@@ -87,7 +87,7 @@ func TestRabbitMQReceiptMetadata(t *testing.T) {
 	t.Run("Should stringify headers and derive the delivery attempt from x-death", func(t *testing.T) {
 		d := amqp.Delivery{
 			Headers: amqp.Table{
-				"x-death": []interface{}{
+				"x-death": []any{
 					amqp.Table{"count": int64(6), "reason": "rejected"},
 				},
 			},

--- a/pkg/messaging/rabbitmq.go
+++ b/pkg/messaging/rabbitmq.go
@@ -181,7 +181,7 @@ func rabbitMQDeliveryAttempt(d amqp.Delivery) *int {
 	if !ok {
 		return nil
 	}
-	entries, ok := death.([]interface{})
+	entries, ok := death.([]any)
 	if !ok || len(entries) == 0 {
 		return nil
 	}


### PR DESCRIPTION
## Summary

Apply the Go modernization suggestions produced by `go fix` across 9 files in monitoring, observer tests, dependency injection, and messaging.

## Initial analysis

Ran:

```bash
go fix -diff ./...
```

The initial diff contained **19 modernization suggestions across 9 files**:

| Count | Suggested change |
| ---: | --- |
| 9 | Replace counted loops with integer `range` loops |
| 3 | Replace `WaitGroup.Add(1)` + goroutine + deferred `Done()` with `WaitGroup.Go` |
| 3 | Replace indexed reflection over function parameters/results with `reflect.Type.Ins()` / `Outs()` |
| 2 | Replace `interface{}` with its alias `any` |
| 1 | Replace a manual map-copy loop with `maps.Copy` |
| 1 | Replace `strings.HasPrefix` + `strings.TrimPrefix` with `strings.CutPrefix` |

## Application process

1. Ran `go fix ./...` to apply the initial suggestions.
2. Ran `go fix -diff ./...` again. It reported two redundant `returnType := returnType` declarations introduced by the first pass in `pkg/di/container.go`.
3. Ran `go fix ./...` a second time to remove those declarations.
4. Removed two leftover blank lines around the transformed `WaitGroup.Go` call in `pkg/messaging/aws.go`.

This amounts to **19 initial modernizations plus 2 follow-up declaration cleanups**. The final diff contains 25 insertions and 36 deletions across 9 files.

## Compatibility and impact

The changes were reviewed for loop bounds and iteration order, task tracking, attribute copying, endpoint normalization, and type equivalence. No functional regression was identified in the reviewed paths or detected by the test suite.

All introduced language features and APIs are available in the Go 1.26 version declared by the project. In particular, `WaitGroup.Go` is available since Go 1.25, and `reflect.Type.Ins()` / `Outs()` since Go 1.26.

Local toolchain reported by `go version`:

```text
go version go1.27.1 darwin/arm64
```

## Validation

| Command | Result |
| --- | --- |
| `go test -timeout 10m ./...` | Passed for all packages with tests; packages without tests compiled successfully |
| `go fix -diff ./...` | No output: no remaining suggestions |
| `git diff --check` | No output: no whitespace errors |

Local tests were run with Go 1.27.1. The repository Quality workflow is configured to run with Go 1.26.